### PR TITLE
apply transparency if nightflyTransparent is enabled

### DIFF
--- a/lua/nightfly/init.lua
+++ b/lua/nightfly/init.lua
@@ -686,7 +686,7 @@ M.style = function()
   highlight(0, "NvimTreeCursorLine", { bg = deep_blue })
   highlight(0, "NvimTreeExecFile", { fg = green })
   highlight(0, "NvimTreeImageFile", { fg = violet })
-  highlight(0, "NvimTreeNormal", { bg = black_blue, fg = white })
+  highlight(0, "NvimTreeNormal", { bg = bg, fg = white })
   highlight(0, "NvimTreeOpenedFile", { fg = yellow })
   highlight(0, "NvimTreeSymlink", { fg = turquoise })
 
@@ -701,7 +701,7 @@ M.style = function()
   highlight(0, "NeoTreeModified", { link = "NightflyYellow" })
   highlight(0, "NeoTreeRootName", { link = "NightflyPurple" })
   highlight(0, "NeoTreeCursorLine", { bg = deep_blue })
-  highlight(0, "NeoTreeNormal", { bg = black_blue, fg = white })
+  highlight(0, "NeoTreeNormal", { bg = bg, fg = white })
 
   -- Telescope plugin
   highlight(0, "TelescopeBorder", { link = "FloatBorder" })


### PR DESCRIPTION
support treesitter background transparency if nightflyTransparent is enabled.
- [v] NvimTree tested
<img width="2926" alt="image" src="https://github.com/bluz71/vim-nightfly-colors/assets/33172368/bddefa89-c1f2-490d-bab4-d8c3283011e7">
