### PR TITLE
new option vim.g.nightflySpellErrorColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ let g:lightline = { 'colorscheme': 'nightfly' }
 | [nightflyUndercurls](https://github.com/bluz71/vim-nightfly-colors#nightflyundercurls)                   | Enabled
 | [nightflyUnderlineMatchParen](https://github.com/bluz71/vim-nightfly-colors#nightflyunderlinematchparen) | Disabled
 | [nightflyVirtualTextColor](https://github.com/bluz71/vim-nightfly-colors#nightflyvirtualtextcolor)       | Disabled
+| [nightflySpellErrorColor](https://github.com/bluz71/vim-nightfly-colors#nightflyspellerrorcolor)         | Enabled
 | [nightflyWinSeparator](https://github.com/bluz71/vim-nightfly-colors#nightflywinseparator)               | `1`
 
 ---
@@ -311,6 +312,25 @@ vim.g.nightflyVirtualTextColor = true
 ```vim
 " Vimscript initialization file
 let g:nightflyVirtualTextColor = v:true
+```
+
+---
+
+### nightflySpellErrorColor
+
+The `nightflySpellErrorColor` option specifies whether to display spelling
+errors in color. By default this option is **enabled**. Note, if undercurls are
+enabled, then this option is ignored. If you prefer not to display spelling
+errors in color then add the following to your initialization file:
+
+```lua
+-- Lua initialization file
+vim.g.nightflySpellErrorColor = false
+```
+
+```vim
+" Vimscript initialization file
+let g:nightflySpellErrorColor = v:false
 ```
 
 ---

--- a/autoload/nightfly.vim
+++ b/autoload/nightfly.vim
@@ -224,11 +224,16 @@ function! nightfly#Style() abort
         exec 'highlight SpellCap ctermbg=NONE cterm=underline guibg=NONE gui=undercurl guisp=' . s:yellow
         exec 'highlight SpellRare ctermbg=NONE cterm=underline guibg=NONE gui=undercurl guisp=' . s:green
         exec 'highlight SpellLocal ctermbg=NONE cterm=underline guibg=NONE gui=undercurl guisp=' . s:blue
-    else
+    elseif g:nightflySpellErrorColor
         exec 'highlight SpellBad ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:red . ' gui=underline guisp=' . s:red
         exec 'highlight SpellCap ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:yellow . ' gui=underline guisp=' . s:yellow
         exec 'highlight SpellRare ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:green . ' gui=underline guisp=' . s:green
         exec 'highlight SpellLocal ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:blue . ' gui=underline guisp=' . s:blue
+    else
+        exec 'highlight SpellBad ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:red
+        exec 'highlight SpellCap ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:yellow
+        exec 'highlight SpellRare ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:green
+        exec 'highlight SpellLocal ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:blue
     endif
 
     " Misc

--- a/colors/nightfly.vim
+++ b/colors/nightfly.vim
@@ -29,6 +29,7 @@ let g:nightflyTransparent = get(g:, 'nightflyTransparent', v:false)
 let g:nightflyUndercurls = get(g:, 'nightflyUndercurls', v:true)
 let g:nightflyUnderlineMatchParen = get(g:, 'nightflyUnderlineMatchParen', v:false)
 let g:nightflyVirtualTextColor =  get(g:, 'nightflyVirtualTextColor', v:false)
+let g:nightflySpellErrorColor =  get(g:, 'nightflySpellErrorColor', v:true)
 let g:nightflyWinSeparator = get(g:, 'nightflyWinSeparator', 1)
 
 if has('nvim')

--- a/doc/nightfly.txt
+++ b/doc/nightfly.txt
@@ -11,6 +11,7 @@ Default option values:
   let g:nightflyTransparent = v:false
   let g:nightflyUndercurls = v:true
   let g:nightflyUnderlineMatchParen = v:false
+  let g:nightflyVirtualTextColor = v:false
   let g:nightflyWinSeparator = 1
 <
 ------------------------------------------------------------------------------

--- a/doc/nightfly.txt
+++ b/doc/nightfly.txt
@@ -1,6 +1,6 @@
 *nightfly* A dark midnight theme for classic Vim & modern Neovim
 
-OPTIONS                                                      *nightfly-options*
+OPTIONS                                                     *nightfly-options*
 
 Default option values:
 >

--- a/doc/nightfly.txt
+++ b/doc/nightfly.txt
@@ -12,6 +12,7 @@ Default option values:
   let g:nightflyUndercurls = v:true
   let g:nightflyUnderlineMatchParen = v:false
   let g:nightflyVirtualTextColor = v:false
+  let g:nightflySpellErrorColor = v:true
   let g:nightflyWinSeparator = 1
 <
 ------------------------------------------------------------------------------
@@ -127,6 +128,20 @@ initialization file:
 
   " Vimscript initialization file
   let g:nightflyVirtualTextColor = v:true
+<
+------------------------------------------------------------------------------
+nightflySpellErrorColor~                           *g:nightflySpellErrorColor*
+
+The `nightflySpellErrorColor` option specifies whether to display spelling
+errors in color. By default this option is **enabled**. Note, if undercurls
+are enabled, then this option is ignored. If you prefer not to display
+spelling errors in color then add the following to your initialization file:
+>
+  -- Lua initialization file
+  vim.g.nightflySpellErrorColor = false
+
+  " Vimscript initialization file
+  let g:nightflySpellErrorColor = v:false
 <
 ------------------------------------------------------------------------------
 nightflyWinSeparator~                                 *g:nightflyWinSeparator*

--- a/lua/nightfly/init.lua
+++ b/lua/nightfly/init.lua
@@ -286,11 +286,16 @@ M.style = function()
     highlight(0, "SpellCap", { bg = none, undercurl = true, sp = yellow })
     highlight(0, "SpellRare", { bg = none, undercurl = true, sp = green })
     highlight(0, "SpellLocal", { bg = none, undercurl = true, sp = blue })
-  else
+  elseif g.nightflySpellErrorColor then
     highlight(0, "SpellBad", { bg = none, fg = red, underline = true, sp = red })
     highlight(0, "SpellCap", { bg = none, fg = yellow, underline = true, sp = yellow })
     highlight(0, "SpellRare", { bg = none, fg = green, underline = true, sp = green })
     highlight(0, "SpellLocal", { bg = none, fg = blue, underline = true, sp = blue })
+  else
+    highlight(0, "SpellBad", { bg = none, underline = true, sp = red })
+    highlight(0, "SpellCap", { bg = none, underline = true, sp = yellow })
+    highlight(0, "SpellRare", { bg = none, underline = true, sp = green })
+    highlight(0, "SpellLocal", { bg = none, underline = true, sp = blue })
   end
 
   -- Misc


### PR DESCRIPTION
The addition of this option is motivated by the behavior of nightflyUndercurls.

When nightflyUndercurls is enabled, which is the default:
- undercurls are used for spelling and linting errors

However, when nightflyUndercurls is disabled:
- underlining is used for spelling and linting errors, and
- spelling errors are highlighted by setting the foreground color

The new option nightflySpellErrorColor can be used to disable the highlighting of spelling errors via foreground color. By default this option is enabled, i.e., underlined spelling errors are also colored.

Note, this new option can NOT be used to enable the highlighting of spelling errors via foreground color when nightflyUndercurls is enabled. Since the default for nightflySpellErrorColor is enabled to maintain current behavior for underlining, doing so would break current behavior for undercurls.

Miscellaneous commits:
- doc: adhere to text width
- doc: add missing default option value