### PR TITLE
feat: wrap Neovim style initialization in pcall

### DIFF
--- a/colors/nightfly.vim
+++ b/colors/nightfly.vim
@@ -3,6 +3,7 @@
 " URL:      github.com/bluz71/vim-nightfly-colors
 " License:  MIT (https://opensource.org/licenses/MIT)
 
+
 " Clear highlights and reset syntax.
 highlight clear
 if exists('syntax_on')
@@ -26,10 +27,10 @@ let g:nightflyWinSeparator = get(g:, 'nightflyWinSeparator', 1)
 
 " Load theme style independently for Neovim and Vim.
 if has('nvim')
-    lua require("nightfly").style()
+    lua pcall(function() require("nightfly").style() end)
 else
     call nightfly#Style()
-end
+endif
 
 set background=dark " nightfly is a dark theme
 set termguicolors   " nightfly is a true-color theme


### PR DESCRIPTION
This pull request encapsulates Neovim-specific Lua initialization in a protected call (`pcall`).


## Why?

Currently, if the nightfly Lua module is missing or encounters an error during load, it can cause the entire Neovim configuration to throw a blocking error on startup. By using pcall, we ensure that:

 - The colorscheme fails gracefully instead of breaking the user's editor.

 - It adds a layer of robustness for different plugin managers and lazy-loading setups.